### PR TITLE
Use H2 for local development.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,22 +16,23 @@ An older version of this sample project that uses Maven is accessible [here](htt
 ## Local Development
 
 ### Starting the application
-
-Start up a PostgreSQL Database Docker container:
-
 ```
-docker run -e POSTGRES_USER=postgres -e POSTGRES_DB=circle_test -p 5432:5432 -itd circleci/postgres:12-alpine
-```
-
-Start up the Java application:
-
-```
-./gradlew bootRun
+./gradlew bootRunDev
 ```
 
 Navigate to http://localhost:8080
 
 ![Screenshot of index page](assets/index.png?raw=true "Screenshot of index page")
+
+We use the [H2 Database](https://www.h2database.com/html/main.html) in memory for 
+local development. You can access the datbase UI at [http://localhost:8080/h2-console](http://localhost:8080/h2-console) 
+with the following credentials. 
+
+```
+username: `sa`
+password: `password`
+JDBC URL: jdbc:h2:mem:testdb
+```
 
 ## License
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,5 +29,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     compile group: 'org.webjars', name: 'bootstrap', version: '3.3.7'
     runtime 'org.postgresql:postgresql:42.2.6'
+    runtime 'com.h2database:h2'
     developmentOnly("org.springframework.boot:spring-boot-devtools")
+}
+
+task bootRunDev(type: org.springframework.boot.gradle.tasks.run.BootRun) {
+    group = 'Application'
+
+    doFirst() {
+        main = bootJar.mainClassName
+        classpath = sourceSets.main.runtimeClasspath
+        systemProperty 'spring.profiles.active', 'local'
+    }
 }

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,12 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password
+
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console


### PR DESCRIPTION
This will allow users who want to try the application out locally to not
have to install docker or postgresql in order to run it.