### PR TITLE
core: Split gradle jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,34 @@
 version: 2
 jobs:
   build:
+    environment:
+      # Configure the JVM and Gradle to avoid OOM errors
+      _JAVA_OPTIONS: "-Xmx3g"
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
+    docker:
+      - image: circleci/openjdk:11.0.3-jdk-stretch
+    steps:
+      - checkout
+      - restore_cache:
+          key: v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+      - restore_cache:
+          key: v1-gradle-cache-{{ checksum "build.gradle" }}
+      - run:
+          name: Install dependencies
+          command: ./gradlew build -x test
+      - save_cache:
+          paths:
+            - ~/.gradle/wrapper
+          key: v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+      - save_cache:
+          paths:
+            - ~/.gradle/caches
+          key: v1-gradle-cache-{{ checksum "build.gradle" }}
+      - persist_to_workspace:
+          root: .
+          paths:
+            - build
+  test:
     # Remove if parallelism is not desired
     parallelism: 2
     environment:
@@ -15,10 +43,8 @@ jobs:
           POSTGRES_DB: circle_test
     steps:
       - checkout
-      - restore_cache:
-          key: v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
-      - restore_cache:
-          key: v1-gradle-cache-{{ checksum "build.gradle" }}
+      - attach_workspace:
+          at: .
       - run:
           name: Run tests in parallel
           # Use "./gradlew test" instead if tests are not run in parallel
@@ -34,18 +60,17 @@ jobs:
             GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
             echo "Prepared arguments for Gradle: $GRADLE_ARGS"
             ./gradlew test $GRADLE_ARGS
-      - save_cache:
-          paths:
-            - ~/.gradle/wrapper
-          key: v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
-      - save_cache:
-          paths:
-            - ~/.gradle/caches
-          key: v1-gradle-cache-{{ checksum "build.gradle" }}
+      - run:
+          name: Generate code coverage report
+          command:
+            ./gradlew jacocoTestReport
       - store_test_results:
           path: build/test-results/test
       - store_artifacts:
           path: build/test-results/test
+          when: always
+      - store_artifacts:
+          path: build/reports/jacoco/test/html
           when: always
       - run:
           name: Assemble JAR
@@ -57,8 +82,12 @@ jobs:
       # This will be empty for all nodes except the first one
       - store_artifacts:
           path: build/libs
+
 workflows:
   version: 2
   workflow:
     jobs:
     - build
+    - test:
+        requires:
+          - build

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # CircleCI 2.0 Java Demo Application using Gradle and Spring [![CircleCI status](https://circleci.com/gh/CircleCI-Public/circleci-demo-java-spring.svg "CircleCI status")](https://circleci.com/gh/CircleCI-Public/circleci-demo-java-spring)
 
+**Note:** This project is currently under substantial development to include additional use cases and show off more features of CircleCI.
+
+If you are coming here form the [Java Language Guide](https://circleci.com/docs/2.0/language-java/#config-walkthrough) please follow along at [this revision](https://github.com/CircleCI-Public/circleci-demo-java-spring/tree/9dcdae5e2988b207e0ac9b6bb9cf8ed711fba4ad) before major changes began to take place.
+
+This message will be removed once the CircleCI documentation matches this repository again.
+
+---
+
 This is an example application showcasing how to run a Java app on CircleCI 2.0.
 
-This application uses the following tools: 
+This application uses the following tools:
 
 * Gradle
 * Java 11
@@ -24,9 +32,9 @@ Navigate to http://localhost:8080
 
 ![Screenshot of index page](assets/index.png?raw=true "Screenshot of index page")
 
-We use the [H2 Database](https://www.h2database.com/html/main.html) in memory for 
-local development. You can access the datbase UI at [http://localhost:8080/h2-console](http://localhost:8080/h2-console) 
-with the following credentials. 
+We use the [H2 Database](https://www.h2database.com/html/main.html) in memory for
+local development. You can access the datbase UI at [http://localhost:8080/h2-console](http://localhost:8080/h2-console)
+with the following credentials.
 
 ```
 username: `sa`

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,13 @@
+// Based on the guide here: https://guides.gradle.org/building-spring-boot-2-projects-with-gradle/
 plugins {
-    id 'org.springframework.boot' version '2.1.6.RELEASE'
     id 'java'
+    id 'com.gradle.build-scan' version '3.0'
+    id 'org.springframework.boot' version '2.2.0.RELEASE'
+    id 'io.spring.dependency-management' version '1.0.8.RELEASE'
 }
 
 apply plugin: 'io.spring.dependency-management'
+apply plugin: 'jacoco'
 
 group = 'com.circleci'
 version = '0.0.1-SNAPSHOT'
@@ -23,13 +27,18 @@ configurations {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-dependencies:2.2.0.RELEASE'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
     compile group: 'org.webjars', name: 'bootstrap', version: '3.3.7'
+
     runtime 'org.postgresql:postgresql:42.2.6'
     runtime 'com.h2database:h2'
+
     developmentOnly("org.springframework.boot:spring-boot-devtools")
 }
 
@@ -42,3 +51,22 @@ task bootRunDev(type: org.springframework.boot.gradle.tasks.run.BootRun) {
         systemProperty 'spring.profiles.active', 'local'
     }
 }
+
+buildScan {
+    // always accept the terms of service
+    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
+
+    // always publish a build scan
+    publishAlways()
+}
+
+// Based on the guide here: https://github.com/codecov/example-gradle
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        html.enabled true
+    }
+}
+
+check.dependsOn jacocoTestReport


### PR DESCRIPTION
This commit adds some additional best pratices to the
gradle configuration and splits up the CircleCI config
into two jobs.